### PR TITLE
CS-9090 Update @hapi/joi to joi

### DIFF
--- a/lib.ts
+++ b/lib.ts
@@ -1,5 +1,5 @@
-import * as Joi from '@hapi/joi';
-import { CustomHelpers } from '@hapi/joi';
+import * as Joi from 'joi';
+import { CustomHelpers } from 'joi';
 import { values } from 'lodash';
 import * as moment from 'moment';
 

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
     "name": "@ksyos/koi",
     "version": "3.2.2",
-    "description": "Some small extensions to @hapi/joi (in Typescript)",
+    "description": "Some small extensions to joi (in Typescript)",
     "main": "lib.js",
     "types": "lib.d.ts",
     "scripts": {
@@ -16,21 +16,19 @@
     },
     "license": "MIT",
     "dependencies": {
-        "@hapi/joi": "^16.1.8",
-        "lodash": "^4.17.15",
-        "moment": "^2.24.0"
+        "joi": "^17.2.1",
+        "lodash": "^4.17.20",
+        "moment": "^2.27.0"
     },
     "devDependencies": {
-        "@types/chai": "^4.2.11",
-        "@types/hapi__joi": "^16.0.12",
-        "@types/lodash": "^4.14.149",
-        "@types/mocha": "^7.0.2",
-        "@types/moment": "^2.13.0",
+        "@types/chai": "^4.2.12",
+        "@types/lodash": "^4.14.160",
+        "@types/mocha": "^8.0.3",
         "chai": "^4.2.0",
-        "concurrently": "^5.1.0",
-        "mocha": "^7.1.1",
-        "source-map-support": "^0.5.16",
-        "tslint": "^6.1.0",
-        "typescript": "^3.8.3"
+        "concurrently": "^5.3.0",
+        "mocha": "^8.1.2",
+        "source-map-support": "^0.5.19",
+        "tslint": "^6.1.3",
+        "typescript": "^4.0.2"
     }
 }

--- a/test.ts
+++ b/test.ts
@@ -1,4 +1,4 @@
-import { AnySchema, ValidationResult } from '@hapi/joi';
+import { AnySchema, ValidationResult } from 'joi';
 import { assert } from 'chai';
 import 'mocha';
 import * as moment from 'moment';


### PR DESCRIPTION
Volgens https://joi.dev/resources/status/#joi wordt versie 17.2.1 alleen ondersteund op Node 12. Dit moet geen probleem meer zijn aangezien we met de overige ontwikkelingen reeds over zijn op Node 12.

https://joi.dev/resources/changelog/ heeft het over een breaking change. Het gaat om deze change: https://github.com/sideway/joi/issues/2284. Volgens mij gebruiken we dat nergens, dus hebben wij hier geen last van.